### PR TITLE
Add styles to logs table, collapse long data

### DIFF
--- a/src/components/Logs/Logs.js
+++ b/src/components/Logs/Logs.js
@@ -14,19 +14,21 @@ const Logs = (props) => {
 	const columnNames = Object.keys(props.logs[0]);
 	const headers = columnNames.map(column => {
 		return (
-			<th>{column}</th>
+			<th key={column}>{column}</th>
 		);
 	});
 
-	const rows = props.logs.map(log => {
+	const rows = props.logs.map((log, index) => {
 		const rowData = columnNames.map(column => {
 			return (
-				<td onClick={handleDataClick}>{log[column]}</td>
+				<td onClick={handleDataClick} key={`${column}-${index}`}>
+					{log[column]}
+				</td>
 			);
 		});
 
 		return (
-			<tr>
+			<tr key={`row-${index}`}>
 				{rowData}
 			</tr>
 		);

--- a/src/components/Logs/Logs.js
+++ b/src/components/Logs/Logs.js
@@ -1,4 +1,14 @@
-import React from 'react';
+import React, { Fragment } from 'react';
+
+function handleDataClick(e) {
+	const cell = e.target;
+
+	if (cell.classList.contains('expanded')) {
+		cell.classList.remove('expanded');
+	} else {
+		cell.classList.add('expanded');
+	}
+}
 
 const Logs = (props) => {
 	const columnNames = Object.keys(props.logs[0]);
@@ -11,7 +21,7 @@ const Logs = (props) => {
 	const rows = props.logs.map(log => {
 		const rowData = columnNames.map(column => {
 			return (
-				<td>{log[column]}</td>
+				<td onClick={handleDataClick}>{log[column]}</td>
 			);
 		});
 
@@ -24,17 +34,23 @@ const Logs = (props) => {
 	console.log('columnNames: ', columnNames);
 
 	return (
-		<table>
-		  <thead>
-		  	<tr>
-		  		{headers}
-		  	</tr>
-		  </thead>
-		  <tbody>
-		    {rows}
-		  </tbody>
-		</table>
-	);	
+		<Fragment>
+			<hr id="logs-table-separator" />
+			<p id="logs-click-instructions">Click on any collapsed piece of data to expand it</p>
+			<div id="logs-table-container">
+				<table>
+					<thead>
+						<tr>
+							{headers}
+						</tr>
+					</thead>
+					<tbody>
+						{rows}
+					</tbody>
+				</table>
+			</div>
+		</Fragment>
+	);
 };
 
 export default Logs;

--- a/src/styles.css
+++ b/src/styles.css
@@ -254,6 +254,35 @@ table {
     outline: none;
 }
 
+#logs-table-container {
+    overflow: scroll;
+}
+
+#logs-table-container tr, td {
+    padding: 10px 15px;
+}
+
+#logs-table-container table td {
+    cursor: pointer;
+}
+
+#logs-table-container table td:not(.expanded) {
+    text-overflow: ellipsis;
+    max-width: 200px;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+#logs-click-instructions {
+    font-size: 1.2em;
+    text-align: center;
+    margin-bottom: 0;
+}
+
+#logs-table-separator {
+    margin-top: 2.5em;
+}
+
 body.tab-navigator button:focus,
 body.tab-navigator input:focus,
 body.tab-navigator select:focus,

--- a/src/styles.css
+++ b/src/styles.css
@@ -262,6 +262,10 @@ table {
     padding: 10px 15px;
 }
 
+#logs-table-container table {
+  min-width: 100%;
+}
+
 #logs-table-container table td {
     cursor: pointer;
 }


### PR DESCRIPTION
This PR adds a small amount of styling and interaction to the query logs table.

Every cell starts out collapsed, and can be expanded if possible.

![image](https://user-images.githubusercontent.com/543973/79528622-54024d80-801f-11ea-8586-eaad72cffddb.png)

![image](https://user-images.githubusercontent.com/543973/79528656-6d0afe80-801f-11ea-85e5-af1c27c23952.png)
